### PR TITLE
fix: crop FFT convolution from the kernel's actual peak throughout

### DIFF
--- a/socca/data.py
+++ b/socca/data.py
@@ -686,7 +686,9 @@ class Image:
             )
 
         if self.noise.__class__.__name__ != "NormalRI":
-            kernel = jp.fft.irfft2(jp.abs(jp.fft.rfft2(kernel)))
+            kernel = jp.fft.irfft2(
+                jp.abs(jp.fft.rfft2(kernel)), s=kernel.shape
+            )
             kernel = jp.fft.ifftshift(kernel)
         else:
             warnings.warn(
@@ -720,13 +722,39 @@ class Convolve:
         self._fft = jp.fft.rfft2
         self._ifft = jp.fft.irfft2
 
-        self._fft_shift = 1.00 + 0j
-        if self.image_shape[0] % 2 != 0:
-            freq = jp.fft.fftfreq(self.padded_shape[0])[:, None]
-            self._fft_shift = jp.exp(2.00j * jp.pi * freq)
-
         self.psf_fft = self._fft(self.kernel, self.padded_shape)
-        self.psf_fft = self.psf_fft * self._fft_shift
+
+        self._crop_start = tuple(
+            int(i)
+            for i in jp.unravel_index(
+                jp.argmax(self.kernel), self.kernel.shape
+            )
+        )
+
+    def crop(self, data_fft):
+        """
+        Inverse-FFT and crop a Fourier-domain array from the kernel's peak.
+
+        Use this directly (instead of __call__) for data that has already
+        been multiplied by self.psf_fft in Fourier space -- e.g. point
+        sources rendered via FFTspec's phase-ramp pulses -- so the crop
+        stays consistent with where __call__ places the kernel's peak.
+        FFTspec.ifft's own crop offset assumes a delta at the image's
+        geometric center and knows nothing about the kernel's peak
+        location, so it cannot be substituted here.
+
+        Parameters
+        ----------
+        data_fft : jax.numpy.ndarray
+            Fourier-domain array of shape self.psf_fft.shape.
+
+        Returns
+        -------
+        jax.numpy.ndarray
+            Image-space array with shape image_shape.
+        """
+        data = self._ifft(data_fft, self.padded_shape)
+        return jax.lax.dynamic_slice(data, self._crop_start, self.image_shape)
 
     def __call__(self, image):
         """
@@ -743,16 +771,4 @@ class Convolve:
             Convolved image with the same shape as the input.
         """
         _image = self._fft(image, self.padded_shape)
-        _image = self._ifft(_image * self.psf_fft, self.padded_shape)
-
-        start = tuple(
-            (f - o) // 2 for f, o in zip(self.padded_shape, self.image_shape)
-        )
-
-        if self.image_shape[0] % 2 == 0:
-            start = (start[0] + 1, start[1])
-
-        if self.image_shape[1] % 2 == 0:
-            start = (start[0], start[1] + 1)
-
-        return jax.lax.dynamic_slice(_image, start, self.image_shape)
+        return self.crop(_image * self.psf_fft)

--- a/socca/models/__init__.py
+++ b/socca/models/__init__.py
@@ -703,9 +703,9 @@ class Model:
 
         if img.psf is not None:
             msmo = img.convolve(msmo)
-            mpts = mpts * img.convolve.psf_fft
-
-        mpts = img.fft.ifft(mpts).real
+            mpts = img.convolve.crop(mpts * img.convolve.psf_fft).real
+        else:
+            mpts = img.fft.ifft(mpts).real
         msmo = msmo + mpts
 
         if doexp:


### PR DESCRIPTION
Convolve previously cropped its FFT convolution result using a content-independent offset ((padded_shape - image_shape) // 2, with a parity correction), which implicitly assumes the kernel's peak sits at array index [0, 0] before this class ever sees it. Real PSF inputs are always center-peaked, not shifted to that origin -- for NormalRI (which skips kernel centering and warns the PSF is assumed pre-centered) every convolution was silently misaligned; the default path centers the kernel via ifftshift, but that lands the peak at ceil(kernel_size/2) for odd sizes, one pixel off from what the old crop offset assumed.

Fix: locate the kernel's actual peak via argmax at __init__ time (Convolve._crop_start) and crop starting there -- exact regardless of where the peak sits, and removes the need for the parity-based _fft_shift phase correction entirely.

Point sources rendered via FFTspec's phase-ramp pulses (models/__init__.py) convolve with the PSF by multiplying their Fourier representation by Convolve.psf_fft and inverse-transforming via FFTspec.ifft -- which has its own, unrelated crop convention (a delta assumed at the image's geometric center) with no knowledge of the kernel's actual peak location. This reintroduced the same misalignment specifically for point sources, on whichever axis was odd-sized, even after the Convolve fix above. Added Convolve.crop() (Fourier-domain input, kernel-peak-aware crop, factored out of __call__) and route the PSF-convolved point-source term through it instead of FFTspec.ifft.

Verified against all four image-parity combinations (even/even, odd/even, even/odd, odd/odd), for both raw array convolution and the full Point-model rendering path; full test suite (326 tests) passes.